### PR TITLE
Fix fish/starfish geometry

### DIFF
--- a/src/Funge.cpp
+++ b/src/Funge.cpp
@@ -136,10 +136,13 @@ int fungemain(int argc, char **argv, char **envp){
 				std::cerr << "Unsupported standard: " << arg << std::endl;
 				return EINVAL;
 			}
-			if(funge_config.standard == Funge::FUNGE_93
-					|| funge_config.standard == Funge::FUNGE_FISH
-					|| funge_config.standard == Funge::FUNGE_STARFISH){
+			if(funge_config.standard == Funge::FUNGE_93){
 				funge_config.topo = Funge::TOPO_TORUS;
+				funge_config.strings = Funge::STRING_MULTISPACE;
+				funge_config.cells = Funge::CELL_CHAR;
+			}else if(funge_config.standard == Funge::FUNGE_FISH
+					|| funge_config.standard == Funge::FUNGE_STARFISH){
+				funge_config.topo = Funge::TOPO_LAHEY;
 				funge_config.strings = Funge::STRING_MULTISPACE;
 				funge_config.cells = Funge::CELL_CHAR;
 			}else{

--- a/src/Funge.cpp
+++ b/src/Funge.cpp
@@ -144,7 +144,7 @@ int fungemain(int argc, char **argv, char **envp){
 					|| funge_config.standard == Funge::FUNGE_STARFISH){
 				funge_config.topo = Funge::TOPO_LAHEY;
 				funge_config.strings = Funge::STRING_MULTISPACE;
-				funge_config.cells = Funge::CELL_CHAR;
+				funge_config.cells = Funge::CELL_INT;
 			}else{
 				funge_config.topo = TOPO_LAHEY;
 				funge_config.strings = STRING_SGML;


### PR DESCRIPTION
Topo should be Lahey, see https://esolangs.org/wiki/Fish#Code_execution "The codebox is infinite in all directions, positive and negative."

This PR also partially fixes cell type. `CELL_FLOAT` doesn't exist, but `CELL_INT` still better than `CELL_CHAR`. Official ><> interpreter has [float cells](https://tio.run/##S8sszvj/39BIx8CgwMAgPc/6/38A).